### PR TITLE
Fixed craftcms/cms requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     }
   ],
   "require": {
-    "craftcms/cms": "~3.0.0-beta.23"
+    "craftcms/cms": "^3.0.0-beta.23"
   },
   "repositories": [
     {


### PR DESCRIPTION
Without this change, the plugin is saying it won’t be compatible with Craft 3.1+, which probably isn’t want you intended.